### PR TITLE
Gui improvement

### DIFF
--- a/femmt/functions.py
+++ b/femmt/functions.py
@@ -800,7 +800,13 @@ def fft(period_vector_t_i: npt.ArrayLike, sample_factor: int = 1000, plot: str =
 def plot_fourier_coefficients(frequency_list, amplitude_list, phi_rad_list, sample_factor: int = 1000,
                               figure_directory: str = None):
     """Plot fourier coefficients in a visual figure."""
-    time_period = 1 / min(frequency_list)
+    # dc and ac handling
+    nonzero_frequencies = [f for f in frequency_list if f != 0]
+    if nonzero_frequencies:
+        time_period = 1 / min(nonzero_frequencies)
+    else:
+        time_period = 1
+    # time_period = 1 / min(frequency_list)
 
     t_interp = np.linspace(0, time_period, sample_factor)
     reconstructed_signal = 0
@@ -830,6 +836,7 @@ def plot_fourier_coefficients(frequency_list, amplitude_list, phi_rad_list, samp
     plt.tight_layout()
     if figure_directory is not None:
         plt.savefig(figure_directory, bbox_inches="tight")
+    plt.close('all')  # close the figures to remove the warning when you run many figures
 
     # plt.show()
 

--- a/femmt/functions.py
+++ b/femmt/functions.py
@@ -1064,43 +1064,73 @@ def visualize_simulation_results(simulation_result_file_path: str, store_figure_
     """Visualize the simulation results by a figure."""
     with open(simulation_result_file_path, "r") as fd:
         loaded_results_dict = json.loads(fd.read())
-    # core eddy and hysteresis losses
-    loss_core_eddy_current = loaded_results_dict["total_losses"]["eddy_core"]
-    loss_core_hysteresis = loaded_results_dict["total_losses"]["hyst_core_fundamental_freq"]
-    # Inductances and winding losses
-    windings_inductance = []
-    windings_loss = []
+
+    # Initialize accumulators for cumulative losses and inductances
+    cumulative_core_hysteresis = 0
+    cumulative_core_eddy = 0
+    cumulative_losses = []
+    cumulative_inductances = []
     windings_labels = []
-    # Dynamically for 3 windings
-    for i in range(1, 3):
-        winding_key = f"winding{i}"
-        if winding_key in loaded_results_dict["single_sweeps"][0]:
-            windings_inductance.append(loaded_results_dict["single_sweeps"][0][winding_key]["flux_over_current"][0])
-            windings_loss.append(loaded_results_dict["total_losses"][winding_key]["total"])
-            windings_labels.append(f"Winding {i}")
 
-    # Plotting results
+    for index, sweep in enumerate(loaded_results_dict["single_sweeps"]):
+        freq = sweep['f']
+        loss_core_eddy_current = sweep.get("core_eddy_losses", 0)
+        loss_core_hysteresis = sweep.get("core_hyst_losses", 0)
+
+        # Accumulate core losses
+        cumulative_core_hysteresis += loss_core_hysteresis
+        cumulative_core_eddy += loss_core_eddy_current
+
+        # Plotting for each frequency
+        fig, ax = plt.subplots()
+        ax.bar(0, loss_core_hysteresis, width=0.35, label='Core Hysteresis Loss')
+        ax.bar(0, loss_core_eddy_current, bottom=loss_core_hysteresis, width=0.35, label='Core Eddy Current Loss')
+
+        for i in range(1, 4):
+            winding_key = f"winding{i}"
+            if winding_key in sweep:
+                inductance = sweep[winding_key].get("flux_over_current", [0])[0]
+                loss = sweep[winding_key].get("winding_losses", 0)
+
+                if len(cumulative_losses) < i:
+                    cumulative_losses.append(loss)
+                    cumulative_inductances.append(inductance)
+                    windings_labels.append(f"Winding {i}")
+                else:
+                    cumulative_losses[i - 1] += loss
+                    cumulative_inductances[i - 1] += inductance
+
+                # Plot for current frequency
+                ax.bar(i, loss, width=0.35, label=f'{windings_labels[i - 1]} Loss at {freq} Hz')
+
+        ax.set_ylabel('Losses in W')
+        ax.set_title(f'Loss Distribution at {freq} Hz')
+        ax.legend()
+        plt.grid(True)
+
+        # Save plot for the current frequency
+        base_path, ext = os.path.splitext(store_figure_file_path)
+        filename = f"{base_path}_{index}{ext}"
+        plt.savefig(filename, bbox_inches="tight")
+        plt.close(fig)
+
+    # Plot cumulative results for core and windings
     fig, ax = plt.subplots()
-    bar_width = 0.35
+    ax.bar(0, cumulative_core_hysteresis, width=0.35, label='Cumulative Core Hysteresis Loss')
+    ax.bar(0, cumulative_core_eddy, bottom=cumulative_core_hysteresis, width=0.35, label='Cumulative Core Eddy Current Loss')
 
-    # Plot core losses
-    ax.bar(0, loss_core_hysteresis, width=bar_width, label='Core Hysteresis Loss')
-    ax.bar(0, loss_core_eddy_current, bottom=loss_core_hysteresis, width=bar_width, label='Core Eddy Current Loss')
+    for index, loss in enumerate(cumulative_losses):
+        ax.bar(index + 1, loss, width=0.35, label=f'{windings_labels[index]} Cumulative Loss')
 
-    # Plot winding inductances and losses
-    for index, (inductance, loss) in enumerate(zip(windings_inductance, windings_loss), start=1):
-        ax.bar(index, loss, width=bar_width, label=f'{windings_labels[index - 1]} Loss')
-        print(f"{windings_labels[index - 1]} Inductance: {inductance} H")
-        print(f"{windings_labels[index - 1]} Loss: {loss} W")
-
-    ax.set_ylabel('Losses in W')
-    ax.set_title('Loss Distribution in Magnetic Components')
-    ax.set_xticks(list(range(len(windings_labels) + 1)))
+    ax.set_ylabel('total Losses in W')
+    ax.set_title('Loss Distribution in Magnetic Components for all frequencies')
+    ax.set_xticks(range(len(windings_labels) + 1))
     ax.set_xticklabels(['Core'] + windings_labels)
     ax.legend()
-
     plt.grid(True)
-    plt.savefig(store_figure_file_path, bbox_inches="tight")
+    base_path, ext = os.path.splitext(store_figure_file_path)
+    cumulative_filename = f"{base_path}_total_freq{ext}"
+    plt.savefig(cumulative_filename, bbox_inches="tight")
 
     if show_plot:
         plt.show()

--- a/femmt/model.py
+++ b/femmt/model.py
@@ -562,13 +562,24 @@ class AirGaps:
         elif self.method == AirGapMethod.Percent:
             if position_value > 100 or position_value < 0:
                 raise Exception("AirGap position values for the percent method need to be between 0 and 100.")
+            # Calculate the maximum and minimum position in percent considering the winding window height and air gap length
+            max_position = 100 - (height / self.core.window_h) * 51
+            min_position = (height / self.core.window_h) * 51
+
+            # Adjust the position value if it exceeds the bounds of 0 to 100 percent
+            if position_value > max_position:
+                position_value = max_position
+            elif position_value < min_position:
+                position_value = min_position
+
             position = position_value / 100 * self.core.window_h - self.core.window_h / 2
 
-            # When the position is above the winding window it needs to be adjusted
+            # # When the position is above the winding window it needs to be adjusted
             if position + height / 2 > self.core.window_h / 2:
                 position -= (position + height / 2) - self.core.window_h / 2
             elif position - height / 2 < -self.core.window_h / 2:
                 position += -self.core.window_h / 2 - (position - height / 2)
+
 
             self.midpoints.append([leg_position.value, position, height])
             self.number += 1

--- a/femmt/model.py
+++ b/femmt/model.py
@@ -580,7 +580,6 @@ class AirGaps:
             elif position - height / 2 < -self.core.window_h / 2:
                 position += -self.core.window_h / 2 - (position - height / 2)
 
-
             self.midpoints.append([leg_position.value, position, height])
             self.number += 1
 

--- a/gui/femmt_gui.py
+++ b/gui/femmt_gui.py
@@ -3240,7 +3240,7 @@ class MainWindow(QMainWindow):
         # Read back results
         # -----------------------------------------------
 
-        self.md_simulation_QLabel.setText('simulation fertig.')
+        self.md_simulation_QLabel.setText('simulation complete.')
 
         # loaded_results_dict = fmt.visualize_simulation_results(geo.file_data.femm_results_log_path, './results.png', show_plot=False)
         loaded_results_dict = fmt.visualize_simulation_results(geo.file_data.e_m_results_log_path,

--- a/gui/femmt_gui.ui
+++ b/gui/femmt_gui.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1656</width>
-    <height>1076</height>
+    <width>1545</width>
+    <height>1177</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -37,7 +37,7 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>1619</width>
+         <width>1508</width>
          <height>1280</height>
         </rect>
        </property>
@@ -45,7 +45,7 @@
         <item>
          <widget class="QTabWidget" name="tabWidget">
           <property name="currentIndex">
-           <number>1</number>
+           <number>0</number>
           </property>
           <widget class="QWidget" name="md_QWidget_2">
            <attribute name="title">
@@ -61,7 +61,7 @@
                </size>
               </property>
               <property name="currentIndex">
-               <number>3</number>
+               <number>2</number>
               </property>
               <widget class="QWidget" name="md_QWidget">
                <attribute name="title">
@@ -1836,47 +1836,690 @@
                     <property name="title">
                      <string>Simulation Text Output</string>
                     </property>
-                    <layout class="QGridLayout" name="gridLayout_22">
-                     <item row="3" column="1">
-                      <widget class="QLabel" name="md_loss_winding2_label">
-                       <property name="text">
-                        <string/>
+                    <layout class="QVBoxLayout" name="verticalLayout_17">
+                     <item>
+                      <widget class="QScrollArea" name="scrollArea_11">
+                       <property name="widgetResizable">
+                        <bool>false</bool>
                        </property>
-                      </widget>
-                     </item>
-                     <item row="0" column="1">
-                      <widget class="QLabel" name="md_loss_core_hysteresis_label">
-                       <property name="text">
-                        <string/>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="1" column="1">
-                      <widget class="QLabel" name="md_loss_core_eddy_current_label">
-                       <property name="text">
-                        <string/>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="4" column="1">
-                      <widget class="QLabel" name="md_inductance1_label">
-                       <property name="text">
-                        <string/>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="2" column="1">
-                      <widget class="QLabel" name="md_loss_winding1_label">
-                       <property name="text">
-                        <string/>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="5" column="1">
-                      <widget class="QLabel" name="md_inductance2_label">
-                       <property name="text">
-                        <string/>
-                       </property>
+                       <widget class="QWidget" name="scrollAreaWidgetContents_11">
+                        <property name="geometry">
+                         <rect>
+                          <x>0</x>
+                          <y>0</y>
+                          <width>641</width>
+                          <height>1137</height>
+                         </rect>
+                        </property>
+                        <layout class="QVBoxLayout" name="verticalLayout_31">
+                         <item>
+                          <widget class="QGroupBox" name="groupBox_41">
+                           <property name="title">
+                            <string/>
+                           </property>
+                           <layout class="QVBoxLayout" name="verticalLayout_35">
+                            <item>
+                             <layout class="QVBoxLayout" name="verticalLayout_34">
+                              <item>
+                               <widget class="QLabel" name="md_freq1">
+                                <property name="text">
+                                 <string/>
+                                </property>
+                               </widget>
+                              </item>
+                              <item>
+                               <layout class="QHBoxLayout" name="horizontalLayout_11">
+                                <item>
+                                 <layout class="QVBoxLayout" name="verticalLayout_32">
+                                  <item>
+                                   <widget class="QLabel" name="md_loss_core_hysteresis_label1">
+                                    <property name="text">
+                                     <string/>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                  <item>
+                                   <widget class="QLabel" name="md_loss_core_eddy_current_label1">
+                                    <property name="text">
+                                     <string/>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                  <item>
+                                   <widget class="QLabel" name="md_loss_winding1_label1">
+                                    <property name="text">
+                                     <string/>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                 </layout>
+                                </item>
+                                <item>
+                                 <layout class="QVBoxLayout" name="verticalLayout_33">
+                                  <item>
+                                   <widget class="QLabel" name="md_loss_winding2_label1">
+                                    <property name="text">
+                                     <string/>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                  <item>
+                                   <widget class="QLabel" name="md_inductance1_label1">
+                                    <property name="text">
+                                     <string/>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                  <item>
+                                   <widget class="QLabel" name="md_inductance2_label1">
+                                    <property name="text">
+                                     <string/>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                 </layout>
+                                </item>
+                               </layout>
+                              </item>
+                             </layout>
+                            </item>
+                           </layout>
+                          </widget>
+                         </item>
+                         <item>
+                          <widget class="QGroupBox" name="groupBox_42">
+                           <property name="title">
+                            <string/>
+                           </property>
+                           <layout class="QVBoxLayout" name="verticalLayout_39">
+                            <item>
+                             <layout class="QVBoxLayout" name="verticalLayout_36">
+                              <item>
+                               <widget class="QLabel" name="md_freq2">
+                                <property name="text">
+                                 <string/>
+                                </property>
+                               </widget>
+                              </item>
+                              <item>
+                               <layout class="QHBoxLayout" name="horizontalLayout_14">
+                                <item>
+                                 <layout class="QVBoxLayout" name="verticalLayout_37">
+                                  <item>
+                                   <widget class="QLabel" name="md_loss_core_hysteresis_label2">
+                                    <property name="text">
+                                     <string/>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                  <item>
+                                   <widget class="QLabel" name="md_loss_core_eddy_current_label2">
+                                    <property name="text">
+                                     <string/>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                  <item>
+                                   <widget class="QLabel" name="md_loss_winding1_label2">
+                                    <property name="text">
+                                     <string/>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                 </layout>
+                                </item>
+                                <item>
+                                 <layout class="QVBoxLayout" name="verticalLayout_38">
+                                  <item>
+                                   <widget class="QLabel" name="md_loss_winding2_label2">
+                                    <property name="text">
+                                     <string/>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                  <item>
+                                   <widget class="QLabel" name="md_inductance1_label2">
+                                    <property name="text">
+                                     <string/>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                  <item>
+                                   <widget class="QLabel" name="md_inductance2_label2">
+                                    <property name="text">
+                                     <string/>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                 </layout>
+                                </item>
+                               </layout>
+                              </item>
+                             </layout>
+                            </item>
+                           </layout>
+                          </widget>
+                         </item>
+                         <item>
+                          <widget class="QGroupBox" name="groupBox_43">
+                           <property name="title">
+                            <string/>
+                           </property>
+                           <layout class="QVBoxLayout" name="verticalLayout_43">
+                            <item>
+                             <layout class="QVBoxLayout" name="verticalLayout_40">
+                              <item>
+                               <widget class="QLabel" name="md_freq3">
+                                <property name="text">
+                                 <string/>
+                                </property>
+                               </widget>
+                              </item>
+                              <item>
+                               <layout class="QHBoxLayout" name="horizontalLayout_15">
+                                <item>
+                                 <layout class="QVBoxLayout" name="verticalLayout_41">
+                                  <item>
+                                   <widget class="QLabel" name="md_loss_core_hysteresis_label3">
+                                    <property name="text">
+                                     <string/>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                  <item>
+                                   <widget class="QLabel" name="md_loss_core_eddy_current_label3">
+                                    <property name="text">
+                                     <string/>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                  <item>
+                                   <widget class="QLabel" name="md_loss_winding1_label3">
+                                    <property name="text">
+                                     <string/>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                 </layout>
+                                </item>
+                                <item>
+                                 <layout class="QVBoxLayout" name="verticalLayout_42">
+                                  <item>
+                                   <widget class="QLabel" name="md_loss_winding2_label3">
+                                    <property name="text">
+                                     <string/>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                  <item>
+                                   <widget class="QLabel" name="md_inductance1_label3">
+                                    <property name="text">
+                                     <string/>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                  <item>
+                                   <widget class="QLabel" name="md_inductance2_label3">
+                                    <property name="text">
+                                     <string/>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                 </layout>
+                                </item>
+                               </layout>
+                              </item>
+                             </layout>
+                            </item>
+                           </layout>
+                          </widget>
+                         </item>
+                         <item>
+                          <widget class="QGroupBox" name="groupBox_44">
+                           <property name="title">
+                            <string/>
+                           </property>
+                           <layout class="QVBoxLayout" name="verticalLayout_47">
+                            <item>
+                             <layout class="QVBoxLayout" name="verticalLayout_44">
+                              <item>
+                               <widget class="QLabel" name="md_freq4">
+                                <property name="text">
+                                 <string/>
+                                </property>
+                               </widget>
+                              </item>
+                              <item>
+                               <layout class="QHBoxLayout" name="horizontalLayout_16">
+                                <item>
+                                 <layout class="QVBoxLayout" name="verticalLayout_45">
+                                  <item>
+                                   <widget class="QLabel" name="md_loss_core_hysteresis_label4">
+                                    <property name="text">
+                                     <string/>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                  <item>
+                                   <widget class="QLabel" name="md_loss_core_eddy_current_label4">
+                                    <property name="text">
+                                     <string/>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                  <item>
+                                   <widget class="QLabel" name="md_loss_winding1_label4">
+                                    <property name="text">
+                                     <string/>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                 </layout>
+                                </item>
+                                <item>
+                                 <layout class="QVBoxLayout" name="verticalLayout_46">
+                                  <item>
+                                   <widget class="QLabel" name="md_loss_winding2_label4">
+                                    <property name="text">
+                                     <string/>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                  <item>
+                                   <widget class="QLabel" name="md_inductance1_label4">
+                                    <property name="text">
+                                     <string/>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                  <item>
+                                   <widget class="QLabel" name="md_inductance2_label4">
+                                    <property name="text">
+                                     <string/>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                 </layout>
+                                </item>
+                               </layout>
+                              </item>
+                             </layout>
+                            </item>
+                           </layout>
+                          </widget>
+                         </item>
+                         <item>
+                          <widget class="QGroupBox" name="groupBox_45">
+                           <property name="title">
+                            <string/>
+                           </property>
+                           <layout class="QVBoxLayout" name="verticalLayout_51">
+                            <item>
+                             <layout class="QVBoxLayout" name="verticalLayout_48">
+                              <item>
+                               <widget class="QLabel" name="md_freq5">
+                                <property name="text">
+                                 <string/>
+                                </property>
+                               </widget>
+                              </item>
+                              <item>
+                               <layout class="QHBoxLayout" name="horizontalLayout_17">
+                                <item>
+                                 <layout class="QVBoxLayout" name="verticalLayout_49">
+                                  <item>
+                                   <widget class="QLabel" name="md_loss_core_hysteresis_label5">
+                                    <property name="text">
+                                     <string/>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                  <item>
+                                   <widget class="QLabel" name="md_loss_core_eddy_current_label5">
+                                    <property name="text">
+                                     <string/>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                  <item>
+                                   <widget class="QLabel" name="md_loss_winding1_label5">
+                                    <property name="text">
+                                     <string/>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                 </layout>
+                                </item>
+                                <item>
+                                 <layout class="QVBoxLayout" name="verticalLayout_50">
+                                  <item>
+                                   <widget class="QLabel" name="md_loss_winding2_label5">
+                                    <property name="text">
+                                     <string/>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                  <item>
+                                   <widget class="QLabel" name="md_inductance1_label5">
+                                    <property name="text">
+                                     <string/>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                  <item>
+                                   <widget class="QLabel" name="md_inductance2_label5">
+                                    <property name="text">
+                                     <string/>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                 </layout>
+                                </item>
+                               </layout>
+                              </item>
+                             </layout>
+                            </item>
+                           </layout>
+                          </widget>
+                         </item>
+                         <item>
+                          <widget class="QGroupBox" name="groupBox_46">
+                           <property name="title">
+                            <string/>
+                           </property>
+                           <layout class="QVBoxLayout" name="verticalLayout_55">
+                            <item>
+                             <layout class="QVBoxLayout" name="verticalLayout_52">
+                              <item>
+                               <widget class="QLabel" name="md_freq6">
+                                <property name="text">
+                                 <string/>
+                                </property>
+                               </widget>
+                              </item>
+                              <item>
+                               <layout class="QHBoxLayout" name="horizontalLayout_18">
+                                <item>
+                                 <layout class="QVBoxLayout" name="verticalLayout_53">
+                                  <item>
+                                   <widget class="QLabel" name="md_loss_core_hysteresis_label6">
+                                    <property name="text">
+                                     <string/>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                  <item>
+                                   <widget class="QLabel" name="md_loss_core_eddy_current_label6">
+                                    <property name="text">
+                                     <string/>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                  <item>
+                                   <widget class="QLabel" name="md_loss_winding1_label6">
+                                    <property name="text">
+                                     <string/>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                 </layout>
+                                </item>
+                                <item>
+                                 <layout class="QVBoxLayout" name="verticalLayout_54">
+                                  <item>
+                                   <widget class="QLabel" name="md_loss_winding2_label6">
+                                    <property name="text">
+                                     <string/>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                  <item>
+                                   <widget class="QLabel" name="md_inductance1_label6">
+                                    <property name="text">
+                                     <string/>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                  <item>
+                                   <widget class="QLabel" name="md_inductance2_label6">
+                                    <property name="text">
+                                     <string/>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                 </layout>
+                                </item>
+                               </layout>
+                              </item>
+                             </layout>
+                            </item>
+                           </layout>
+                          </widget>
+                         </item>
+                         <item>
+                          <widget class="QGroupBox" name="groupBox_47">
+                           <property name="title">
+                            <string/>
+                           </property>
+                           <layout class="QVBoxLayout" name="verticalLayout_59">
+                            <item>
+                             <layout class="QVBoxLayout" name="verticalLayout_56">
+                              <item>
+                               <widget class="QLabel" name="md_freq7">
+                                <property name="text">
+                                 <string/>
+                                </property>
+                               </widget>
+                              </item>
+                              <item>
+                               <layout class="QHBoxLayout" name="horizontalLayout_19">
+                                <item>
+                                 <layout class="QVBoxLayout" name="verticalLayout_57">
+                                  <item>
+                                   <widget class="QLabel" name="md_loss_core_hysteresis_label7">
+                                    <property name="text">
+                                     <string/>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                  <item>
+                                   <widget class="QLabel" name="md_loss_core_eddy_current_label7">
+                                    <property name="text">
+                                     <string/>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                  <item>
+                                   <widget class="QLabel" name="md_loss_winding1_label7">
+                                    <property name="text">
+                                     <string/>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                 </layout>
+                                </item>
+                                <item>
+                                 <layout class="QVBoxLayout" name="verticalLayout_58">
+                                  <item>
+                                   <widget class="QLabel" name="md_loss_winding2_label7">
+                                    <property name="text">
+                                     <string/>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                  <item>
+                                   <widget class="QLabel" name="md_inductance1_label7">
+                                    <property name="text">
+                                     <string/>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                  <item>
+                                   <widget class="QLabel" name="md_inductance2_label7">
+                                    <property name="text">
+                                     <string/>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                 </layout>
+                                </item>
+                               </layout>
+                              </item>
+                             </layout>
+                            </item>
+                           </layout>
+                          </widget>
+                         </item>
+                         <item>
+                          <widget class="QGroupBox" name="groupBox_48">
+                           <property name="title">
+                            <string/>
+                           </property>
+                           <layout class="QVBoxLayout" name="verticalLayout_63">
+                            <item>
+                             <layout class="QVBoxLayout" name="verticalLayout_60">
+                              <item>
+                               <widget class="QLabel" name="md_freq8">
+                                <property name="text">
+                                 <string/>
+                                </property>
+                               </widget>
+                              </item>
+                              <item>
+                               <layout class="QHBoxLayout" name="horizontalLayout_20">
+                                <item>
+                                 <layout class="QVBoxLayout" name="verticalLayout_61">
+                                  <item>
+                                   <widget class="QLabel" name="md_loss_core_hysteresis_label8">
+                                    <property name="text">
+                                     <string/>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                  <item>
+                                   <widget class="QLabel" name="md_loss_core_eddy_current_label8">
+                                    <property name="text">
+                                     <string/>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                  <item>
+                                   <widget class="QLabel" name="md_loss_winding1_label8">
+                                    <property name="text">
+                                     <string/>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                 </layout>
+                                </item>
+                                <item>
+                                 <layout class="QVBoxLayout" name="verticalLayout_62">
+                                  <item>
+                                   <widget class="QLabel" name="md_loss_winding2_label8">
+                                    <property name="text">
+                                     <string/>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                  <item>
+                                   <widget class="QLabel" name="md_inductance1_label8">
+                                    <property name="text">
+                                     <string/>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                  <item>
+                                   <widget class="QLabel" name="md_inductance2_label8">
+                                    <property name="text">
+                                     <string/>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                 </layout>
+                                </item>
+                               </layout>
+                              </item>
+                             </layout>
+                            </item>
+                           </layout>
+                          </widget>
+                         </item>
+                         <item>
+                          <widget class="QGroupBox" name="groupBox_49">
+                           <property name="title">
+                            <string/>
+                           </property>
+                           <layout class="QVBoxLayout" name="verticalLayout_67">
+                            <item>
+                             <layout class="QVBoxLayout" name="verticalLayout_64">
+                              <item>
+                               <widget class="QLabel" name="md_freq9">
+                                <property name="text">
+                                 <string/>
+                                </property>
+                               </widget>
+                              </item>
+                              <item>
+                               <layout class="QHBoxLayout" name="horizontalLayout_21">
+                                <item>
+                                 <layout class="QVBoxLayout" name="verticalLayout_65">
+                                  <item>
+                                   <widget class="QLabel" name="md_loss_core_hysteresis_label9">
+                                    <property name="text">
+                                     <string/>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                  <item>
+                                   <widget class="QLabel" name="md_loss_core_eddy_current_label9">
+                                    <property name="text">
+                                     <string/>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                  <item>
+                                   <widget class="QLabel" name="md_loss_winding1_label9">
+                                    <property name="text">
+                                     <string/>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                 </layout>
+                                </item>
+                                <item>
+                                 <layout class="QVBoxLayout" name="verticalLayout_66">
+                                  <item>
+                                   <widget class="QLabel" name="md_loss_winding2_label9">
+                                    <property name="text">
+                                     <string/>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                  <item>
+                                   <widget class="QLabel" name="md_inductance1_label9">
+                                    <property name="text">
+                                     <string/>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                  <item>
+                                   <widget class="QLabel" name="md_inductance2_label9">
+                                    <property name="text">
+                                     <string/>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                 </layout>
+                                </item>
+                               </layout>
+                              </item>
+                             </layout>
+                            </item>
+                           </layout>
+                          </widget>
+                         </item>
+                        </layout>
+                       </widget>
                       </widget>
                      </item>
                     </layout>
@@ -1887,12 +2530,37 @@
                     <property name="title">
                      <string>Simulation Visual Output</string>
                     </property>
-                    <layout class="QGridLayout" name="gridLayout_24">
-                     <item row="0" column="0">
-                      <widget class="QLabel" name="md_loss_plot_label">
-                       <property name="text">
-                        <string/>
+                    <layout class="QVBoxLayout" name="verticalLayout_19">
+                     <item>
+                      <widget class="QScrollArea" name="scrollArea_12">
+                       <property name="widgetResizable">
+                        <bool>false</bool>
                        </property>
+                       <widget class="QWidget" name="scrollAreaWidgetContents_12">
+                        <property name="geometry">
+                         <rect>
+                          <x>0</x>
+                          <y>0</y>
+                          <width>619</width>
+                          <height>1137</height>
+                         </rect>
+                        </property>
+                        <layout class="QVBoxLayout" name="verticalLayout_68">
+                         <item>
+                          <widget class="QLabel" name="md_loss_plot_label1">
+                           <property name="sizePolicy">
+                            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                             <horstretch>0</horstretch>
+                             <verstretch>0</verstretch>
+                            </sizepolicy>
+                           </property>
+                           <property name="text">
+                            <string/>
+                           </property>
+                          </widget>
+                         </item>
+                        </layout>
+                       </widget>
                       </widget>
                      </item>
                     </layout>
@@ -3854,7 +4522,7 @@
                               <rect>
                                <x>0</x>
                                <y>0</y>
-                               <width>635</width>
+                               <width>98</width>
                                <height>518</height>
                               </rect>
                              </property>
@@ -4026,7 +4694,7 @@
                                 <rect>
                                  <x>0</x>
                                  <y>0</y>
-                                 <width>468</width>
+                                 <width>98</width>
                                  <height>518</height>
                                 </rect>
                                </property>
@@ -4081,7 +4749,7 @@
                     <rect>
                      <x>0</x>
                      <y>0</y>
-                     <width>1551</width>
+                     <width>1440</width>
                      <height>1172</height>
                     </rect>
                    </property>
@@ -4212,7 +4880,7 @@
                             <rect>
                              <x>0</x>
                              <y>0</y>
-                             <width>1511</width>
+                             <width>1400</width>
                              <height>807</height>
                             </rect>
                            </property>
@@ -4253,7 +4921,7 @@
             <item row="0" column="0">
              <widget class="QTabWidget" name="tabWidget_2">
               <property name="currentIndex">
-               <number>0</number>
+               <number>2</number>
               </property>
               <widget class="QWidget" name="tab_6">
                <attribute name="title">
@@ -4283,7 +4951,7 @@
                        <rect>
                         <x>0</x>
                         <y>0</y>
-                        <width>1514</width>
+                        <width>98</width>
                         <height>2036</height>
                        </rect>
                       </property>
@@ -8872,7 +9540,7 @@
                        <rect>
                         <x>0</x>
                         <y>0</y>
-                        <width>1514</width>
+                        <width>98</width>
                         <height>1024</height>
                        </rect>
                       </property>
@@ -8926,15 +9594,18 @@
                    </item>
                    <item row="1" column="0">
                     <widget class="QScrollArea" name="scrollArea_10">
+                     <property name="autoFillBackground">
+                      <bool>false</bool>
+                     </property>
                      <property name="widgetResizable">
-                      <bool>true</bool>
+                      <bool>false</bool>
                      </property>
                      <widget class="QWidget" name="scrollAreaWidgetContents_10">
                       <property name="geometry">
                        <rect>
                         <x>0</x>
                         <y>0</y>
-                        <width>1531</width>
+                        <width>1329</width>
                         <height>967</height>
                        </rect>
                       </property>
@@ -9483,7 +10154,7 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>1656</width>
+     <width>1545</width>
      <height>21</height>
     </rect>
    </property>

--- a/gui/femmt_gui.ui
+++ b/gui/femmt_gui.ui
@@ -45,7 +45,7 @@
         <item>
          <widget class="QTabWidget" name="tabWidget">
           <property name="currentIndex">
-           <number>0</number>
+           <number>2</number>
           </property>
           <widget class="QWidget" name="md_QWidget_2">
            <attribute name="title">
@@ -4749,8 +4749,8 @@
                     <rect>
                      <x>0</x>
                      <y>0</y>
-                     <width>1440</width>
-                     <height>1172</height>
+                     <width>268</width>
+                     <height>253</height>
                     </rect>
                    </property>
                    <layout class="QGridLayout" name="gridLayout_46">
@@ -4880,8 +4880,8 @@
                             <rect>
                              <x>0</x>
                              <y>0</y>
-                             <width>1400</width>
-                             <height>807</height>
+                             <width>98</width>
+                             <height>518</height>
                             </rect>
                            </property>
                            <layout class="QVBoxLayout" name="verticalLayout_11">
@@ -4921,7 +4921,7 @@
             <item row="0" column="0">
              <widget class="QTabWidget" name="tabWidget_2">
               <property name="currentIndex">
-               <number>2</number>
+               <number>0</number>
               </property>
               <widget class="QWidget" name="tab_6">
                <attribute name="title">
@@ -4951,7 +4951,7 @@
                        <rect>
                         <x>0</x>
                         <y>0</y>
-                        <width>98</width>
+                        <width>1403</width>
                         <height>2036</height>
                        </rect>
                       </property>
@@ -9444,7 +9444,7 @@
                    <item row="4" column="2">
                     <widget class="QLabel" name="label_219">
                      <property name="text">
-                      <string>T</string>
+                      <string>Hz</string>
                      </property>
                     </widget>
                    </item>
@@ -9454,7 +9454,7 @@
                    <item row="4" column="4">
                     <widget class="QLabel" name="label_220">
                      <property name="text">
-                      <string>T</string>
+                      <string>Hz</string>
                      </property>
                     </widget>
                    </item>
@@ -9464,7 +9464,7 @@
                    <item row="4" column="6">
                     <widget class="QLabel" name="label_242">
                      <property name="text">
-                      <string>T</string>
+                      <string>Hz</string>
                      </property>
                     </widget>
                    </item>
@@ -9474,7 +9474,7 @@
                    <item row="4" column="8">
                     <widget class="QLabel" name="label_224">
                      <property name="text">
-                      <string>T</string>
+                      <string>Hz</string>
                      </property>
                     </widget>
                    </item>
@@ -9484,7 +9484,7 @@
                    <item row="4" column="10">
                     <widget class="QLabel" name="label_243">
                      <property name="text">
-                      <string>T</string>
+                      <string>Hz</string>
                      </property>
                     </widget>
                    </item>
@@ -9492,6 +9492,9 @@
                     <spacer name="horizontalSpacer_41">
                      <property name="orientation">
                       <enum>Qt::Horizontal</enum>
+                     </property>
+                     <property name="sizeType">
+                      <enum>QSizePolicy::Expanding</enum>
                      </property>
                      <property name="sizeHint" stdset="0">
                       <size>
@@ -9540,7 +9543,7 @@
                        <rect>
                         <x>0</x>
                         <y>0</y>
-                        <width>98</width>
+                        <width>1403</width>
                         <height>1024</height>
                        </rect>
                       </property>


### PR DESCRIPTION
fixing excitation sweep simulation in gui. 
fixing dc plot in the excitation tab.
Note that choosing litz wire will cause an error in excitation sweep if the freq is more than IM Hz because Litz Coefficients only implemented for X<=1.25. So the base freq in gui could be reduced. 