### PR TITLE
Fixing gui import error and adding some minor convenience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ femmt/examples/femm
 femmt/examples/mesh
 femmt/custom_examples
 gui/femmt
+gui/GUI_working_directory
 .idea/
 femmt/__pycache__/
 gpgit/

--- a/femmt/component.py
+++ b/femmt/component.py
@@ -4258,7 +4258,7 @@ class MagneticComponent:
 
     def calculate_average_files(self):
         """
-        find the average value of all .dat files within the 'value' directory and each 'Winding_n' subdirectory.
+        Find the average value of all .dat files within the 'value' directory and each 'Winding_n' subdirectory.
 
         - For each .dat file, the method reads the time steps and corresponding data points.
         - Computes the average value by dividing the integral by the total duration of the time steps.

--- a/femmt/functions_reluctance.py
+++ b/femmt/functions_reluctance.py
@@ -204,7 +204,7 @@ def calculate_core_2daxi_total_volume(core_inner_diameter: Union[float, np.array
 def calculate_r_outer(core_inner_diameter: Union[float, np.array], window_w: Union[float, np.array],
                       outer_core_cross_section_scale: Union[float, np.array] = 1.0) -> Union[float, np.array]:
     """
-    calculate outer core radius.
+    Calculate outer core radius.
 
     Default assumption: outer core cross-section is same as inner core cross-section.
 

--- a/gui/femmt_gui.py
+++ b/gui/femmt_gui.py
@@ -3047,7 +3047,6 @@ class MainWindow(QMainWindow):
         returns: femmt MagneticComponent
 
         """
-
         if self.md_simulation_type_comboBox.currentText() == self.translation_dict['inductor']:
             self.md_simulation_QLabel.setText('simulation starts...')
 

--- a/gui/femmt_gui.py
+++ b/gui/femmt_gui.py
@@ -21,7 +21,7 @@ from PyQt5.QtCore import QObject, pyqtSignal, pyqtSlot, QThread, QCoreApplicatio
 import materialdatabase as mdb
 import matplotlib.pyplot as plt
 
-from gui.onelab_path_popup import OnelabPathDialog
+from onelab_path_popup import OnelabPathDialog
 
 from femmt.examples.inductor_optimization import AutomatedDesign
 from femmt.examples.inductor_optimization import load_fem_simulation_results, filter_after_fem
@@ -3047,8 +3047,6 @@ class MainWindow(QMainWindow):
         returns: femmt MagneticComponent
 
         """
-        # geo = fmt.MagneticComponent(component_type=fmt.ComponentType.Inductor, is_gui=True)
-        # self.check_onelab_config(geo)
 
         if self.md_simulation_type_comboBox.currentText() == self.translation_dict['inductor']:
             self.md_simulation_QLabel.setText('simulation starts...')
@@ -3064,7 +3062,9 @@ class MainWindow(QMainWindow):
 
             geo = fmt.MagneticComponent(component_type=fmt.ComponentType.Inductor,
                                         working_directory=self.md_working_directory_lineEdit.text(),
+                                        is_gui=True,
                                         verbosity=fmt.Verbosity.ToConsole)
+            self.check_onelab_config(geo)
 
             core_dimensions = fmt.dtos.SingleCoreDimensions(core_inner_diameter=comma_str_to_point_float(self.md_core_width_lineEdit.text()),
                                                             window_w=comma_str_to_point_float(self.md_window_width_lineEdit.text()),
@@ -3246,7 +3246,9 @@ class MainWindow(QMainWindow):
             # 1. chose simulation type
             geo = fmt.MagneticComponent(component_type=fmt.ComponentType.Transformer,
                                         working_directory=self.md_working_directory_lineEdit.text(),
+                                        is_gui=True,
                                         verbosity=fmt.Verbosity.ToConsole)
+            self.check_onelab_config(geo)
 
             # -----------------------------------------------
             # Core

--- a/gui/femmt_gui.ui
+++ b/gui/femmt_gui.ui
@@ -61,7 +61,7 @@
                </size>
               </property>
               <property name="currentIndex">
-               <number>3</number>
+               <number>0</number>
               </property>
               <widget class="QWidget" name="md_QWidget">
                <attribute name="title">
@@ -2852,7 +2852,7 @@
                </size>
               </property>
               <property name="currentIndex">
-               <number>3</number>
+               <number>0</number>
               </property>
               <widget class="QWidget" name="md_QWidget_3">
                <attribute name="title">


### PR DESCRIPTION
Fixing onelab path setup so I can show this repo to my professor with the gui working out of the box.

- `gui` is not a package and the script is in the same folder, so no prefix is needed.
- Reenable the commented out argument and function call. This way the popup will appear if no `femmt/config.json` is found.
- Change the default `QTab`s to the "Definition" rather then the _empty_ "Simulation" tab.
- Ignore the working directory to keep git status clean.

