### PR TITLE
Fix wrong winding loss calculation in reluctance model for inductor / stacked transformer / integrated transformer

### DIFF
--- a/femmt/optimization/io.py
+++ b/femmt/optimization/io.py
@@ -324,7 +324,8 @@ class InductorOptimization:
                     iso_core_top=reluctance_input.insulations.core_top, iso_core_bot=reluctance_input.insulations.core_bot,
                     frequency=fft_frequency, litz_wire_material_name='Copper', temperature=reluctance_input.temperature)
 
-                p_winding += proximity_factor_assumption * winding_dc_resistance * reluctance_input.fft_amplitude_list[count] ** 2
+                # factor 0.5 due to RMS value needed, but fft returns peak values
+                p_winding += proximity_factor_assumption * winding_dc_resistance * 0.5 * reluctance_input.fft_amplitude_list[count] ** 2
 
             p_loss = p_winding + p_core
 

--- a/femmt/optimization/ito.py
+++ b/femmt/optimization/ito.py
@@ -378,8 +378,8 @@ class IntegratedTransformerOptimization:
                     r_1=reluctance_input.insulations.iso_window_top_core_left,
                     frequency=fft_frequency, winding_area=winding_area_1_top,
                     litz_wire_material_name='Copper', temperature=reluctance_input.temperature)
-
-                p_winding_1_top += proximity_factor_1_top * primary_resistance_top * reluctance_input.fft_amplitude_list_1[count] ** 2
+                # factor 0.5 due to RMS value needed, but fft returns peak values
+                p_winding_1_top += proximity_factor_1_top * primary_resistance_top * 0.5 * reluctance_input.fft_amplitude_list_1[count] ** 2
 
                 if number_bot_prim_turns_per_column > reluctance_input.turns_1_bot:
                     winding_area_1_bot = 2 * reluctance_input.litz_dict_1["conductor_radii"] * \
@@ -409,9 +409,9 @@ class IntegratedTransformerOptimization:
                         window_h=reluctance_input.window_h_bot,
                         iso_core_top=reluctance_input.insulations.iso_window_bot_core_top, iso_core_bot=reluctance_input.insulations.iso_window_bot_core_bot,
                         frequency=fft_frequency, litz_wire_material_name='Copper', temperature=reluctance_input.temperature)
-
-                p_winding_1_bot_inner = proximity_factor_1_bot_inner * primary_resistance_bot_inner * reluctance_input.fft_amplitude_list_1[count] ** 2
-                p_winding_1_bot_outer = proximity_factor_1_bot_outer * primary_resistance_bot_outer * reluctance_input.fft_amplitude_list_1[count] ** 2
+                # factor 0.5 due to RMS value needed, but fft returns peak values
+                p_winding_1_bot_inner = proximity_factor_1_bot_inner * primary_resistance_bot_inner * 0.5 * reluctance_input.fft_amplitude_list_1[count] ** 2
+                p_winding_1_bot_outer = proximity_factor_1_bot_outer * primary_resistance_bot_outer * 0.5 * reluctance_input.fft_amplitude_list_1[count] ** 2
 
                 p_winding_1_bot += p_winding_1_bot_inner + p_winding_1_bot_outer
 
@@ -421,8 +421,8 @@ class IntegratedTransformerOptimization:
                     litz_wire_name=reluctance_input.litz_wire_name_2, number_turns=reluctance_input.turns_2_bot, window_h=reluctance_input.window_h_bot,
                     iso_core_top=reluctance_input.insulations.iso_window_bot_core_top, iso_core_bot=reluctance_input.insulations.iso_window_bot_core_bot,
                     frequency=fft_frequency, litz_wire_material_name='Copper', temperature=reluctance_input.temperature)
-
-                p_winding_2 += proximity_factor_assumption_2 * secondary_resistance * reluctance_input.fft_amplitude_list_2[count] ** 2
+                # factor 0.5 due to RMS value needed, but fft returns peak values
+                p_winding_2 += proximity_factor_assumption_2 * secondary_resistance * 0.5 * reluctance_input.fft_amplitude_list_2[count] ** 2
 
             p_loss_total = p_hyst + p_winding_1_top + p_winding_1_bot + p_winding_2
 

--- a/femmt/optimization/sto.py
+++ b/femmt/optimization/sto.py
@@ -473,7 +473,7 @@ class StackedTransformerOptimization:
                         iso_core_top=reluctance_input.insulations.iso_window_bot_core_top, iso_core_bot=reluctance_input.insulations.iso_window_bot_core_bot,
                         frequency=fft_frequency, litz_wire_material_name='Copper', temperature=reluctance_input.temperature)
                 # factor 0.5 due to RMS value needed, but fft returns peak values
-                p_winding_1_bot_inner = proximity_factor_1_bot_inner * primary_resistance_bot_inner * 0.5 *  reluctance_input.fft_amplitude_list_1[count] ** 2
+                p_winding_1_bot_inner = proximity_factor_1_bot_inner * primary_resistance_bot_inner * 0.5 * reluctance_input.fft_amplitude_list_1[count] ** 2
                 p_winding_1_bot_outer = proximity_factor_1_bot_outer * primary_resistance_bot_outer * 0.5 * reluctance_input.fft_amplitude_list_1[count] ** 2
 
                 p_winding_1_bot += p_winding_1_bot_inner + p_winding_1_bot_outer

--- a/femmt/optimization/sto.py
+++ b/femmt/optimization/sto.py
@@ -442,7 +442,7 @@ class StackedTransformerOptimization:
                     frequency=fft_frequency, winding_area=winding_area_1_top,
                     litz_wire_material_name='Copper', temperature=reluctance_input.temperature)
 
-                p_winding_1_top += proximity_factor_1_top * primary_resistance_top * reluctance_input.fft_amplitude_list_1[count] ** 2
+                p_winding_1_top += proximity_factor_1_top * primary_resistance_top * 0.5 * reluctance_input.fft_amplitude_list_1[count] ** 2
 
                 if number_bot_prim_turns_per_column > reluctance_input.turns_1_bot:
                     winding_area_1_bot = 2 * reluctance_input.primary_litz_dict["conductor_radii"] * \

--- a/femmt/optimization/sto.py
+++ b/femmt/optimization/sto.py
@@ -472,9 +472,9 @@ class StackedTransformerOptimization:
                         window_h=reluctance_input.window_h_bot,
                         iso_core_top=reluctance_input.insulations.iso_window_bot_core_top, iso_core_bot=reluctance_input.insulations.iso_window_bot_core_bot,
                         frequency=fft_frequency, litz_wire_material_name='Copper', temperature=reluctance_input.temperature)
-
-                p_winding_1_bot_inner = proximity_factor_1_bot_inner * primary_resistance_bot_inner * reluctance_input.fft_amplitude_list_1[count] ** 2
-                p_winding_1_bot_outer = proximity_factor_1_bot_outer * primary_resistance_bot_outer * reluctance_input.fft_amplitude_list_1[count] ** 2
+                # factor 0.5 due to RMS value needed, but fft returns peak values
+                p_winding_1_bot_inner = proximity_factor_1_bot_inner * primary_resistance_bot_inner * 0.5 *  reluctance_input.fft_amplitude_list_1[count] ** 2
+                p_winding_1_bot_outer = proximity_factor_1_bot_outer * primary_resistance_bot_outer * 0.5 * reluctance_input.fft_amplitude_list_1[count] ** 2
 
                 p_winding_1_bot += p_winding_1_bot_inner + p_winding_1_bot_outer
 
@@ -484,8 +484,8 @@ class StackedTransformerOptimization:
                     litz_wire_name=reluctance_input.litz_wire_name_2, number_turns=reluctance_input.turns_2_bot, window_h=reluctance_input.window_h_bot,
                     iso_core_top=reluctance_input.insulations.iso_window_bot_core_top, iso_core_bot=reluctance_input.insulations.iso_window_bot_core_bot,
                     frequency=fft_frequency, litz_wire_material_name='Copper', temperature=reluctance_input.temperature)
-
-                p_winding_2 += proximity_factor_assumption_2 * secondary_resistance * reluctance_input.fft_amplitude_list_2[count] ** 2
+                # factor 0.5 due to RMS value needed, but fft returns peak values
+                p_winding_2 += proximity_factor_assumption_2 * secondary_resistance * 0.5 * reluctance_input.fft_amplitude_list_2[count] ** 2
 
             p_loss_total = p_hyst + p_winding_1_top + p_winding_1_bot + p_winding_2
 


### PR DESCRIPTION
@SevenOfNinePE for your information

P_winding = R_DC * I_RMS ** 2
unfortunately, I_peak has been used instead of I_RMS